### PR TITLE
Objective function to minimize acceleration

### DIFF
--- a/teb_local_planner/include/teb_local_planner/g2o_types/edge_acceleration.h
+++ b/teb_local_planner/include/teb_local_planner/g2o_types/edge_acceleration.h
@@ -32,7 +32,7 @@
  *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * Notes:
  * The following class is derived from a class defined by the
  * g2o-framework. g2o is licensed under the terms of the BSD License.
@@ -53,17 +53,19 @@
 
 #include <geometry_msgs/msg/twist.hpp>
 
+
+
 namespace teb_local_planner
 {
 
 /**
  * @class EdgeAcceleration
  * @brief Edge defining the cost function for limiting the translational and rotational acceleration.
- * 
+ *
  * The edge depends on five vertices \f$ \mathbf{s}_i, \mathbf{s}_{ip1}, \mathbf{s}_{ip2}, \Delta T_i, \Delta T_{ip1} \f$ and minimizes:
  * \f$ \min \textrm{penaltyInterval}( [a, omegadot } ]^T ) \cdot weight \f$. \n
  * \e a is calculated using the difference quotient (twice) and the position parts of all three poses \n
- * \e omegadot is calculated using the difference quotient of the yaw angles followed by a normalization to [-pi, pi]. \n 
+ * \e omegadot is calculated using the difference quotient of the yaw angles followed by a normalization to [-pi, pi]. \n
  * \e weight can be set using setInformation() \n
  * \e penaltyInterval denotes the penalty function, see penaltyBoundToInterval() \n
  * The dimension of the error / cost vector is 2: the first component represents the translational acceleration and
@@ -73,22 +75,22 @@ namespace teb_local_planner
  * @see EdgeAccelerationGoal
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationStart() and EdgeAccelerationGoal() for defining boundary values!
- */    
-class EdgeAcceleration : public BaseTebMultiEdge<2, double>
+ */
+class EdgeAcceleration : public BaseTebMultiEdge<4, double>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */ 
+   */
   EdgeAcceleration()
   {
     this->resize(5);
   }
-    
+
   /**
    * @brief Actual cost function
-   */   
+   */
   void computeError()
   {
     TEB_ASSERT_MSG(cfg_, "You must call setTebConfig on EdgeAcceleration()");
@@ -101,50 +103,60 @@ public:
     // VELOCITY & ACCELERATION
     const Eigen::Vector2d diff1 = pose2->position() - pose1->position();
     const Eigen::Vector2d diff2 = pose3->position() - pose2->position();
-        
+
     double dist1 = diff1.norm();
     double dist2 = diff2.norm();
     const double angle_diff1 = g2o::normalize_theta(pose2->theta() - pose1->theta());
     const double angle_diff2 = g2o::normalize_theta(pose3->theta() - pose2->theta());
-    
+
     if (cfg_->trajectory.exact_arc_length) // use exact arc length instead of Euclidean approximation
     {
-        if (angle_diff1 != 0)
-        {
-            const double radius =  dist1/(2*sin(angle_diff1/2));
-            dist1 = fabs( angle_diff1 * radius ); // actual arg length!
-        }
-        if (angle_diff2 != 0)
-        {
-            const double radius =  dist2/(2*sin(angle_diff2/2));
-            dist2 = fabs( angle_diff2 * radius ); // actual arg length!
-        }
+      if (angle_diff1 != 0)
+      {
+        const double sin = std::sin(angle_diff1 / 2);
+        const double radius =  dist1 / (2*sin);
+        dist1 = fabs( angle_diff1 * radius ); // actual arg length!
+      }
+      if (angle_diff2 != 0)
+      {
+        const double sin = std::sin(angle_diff2 / 2);
+        const double radius =  dist2 / (2*sin);
+        dist2 = fabs( angle_diff2 * radius ); // actual arg length!
+      }
     }
-    
+
     double vel1 = dist1 / dt1->dt();
     double vel2 = dist2 / dt2->dt();
-    
-    
+
+
     // consider directions
-//     vel1 *= g2o::sign(diff1[0]*cos(pose1->theta()) + diff1[1]*sin(pose1->theta())); 
-//     vel2 *= g2o::sign(diff2[0]*cos(pose2->theta()) + diff2[1]*sin(pose2->theta())); 
-    vel1 *= fast_sigmoid( 100*(diff1.x()*cos(pose1->theta()) + diff1.y()*sin(pose1->theta())) ); 
-    vel2 *= fast_sigmoid( 100*(diff2.x()*cos(pose2->theta()) + diff2.y()*sin(pose2->theta())) ); 
-    
+    double s1 = std::sin(pose1->theta());
+    double s2 = std::sin(pose2->theta());
+    double c1 = std::cos(pose1->theta());
+    double c2 = std::cos(pose2->theta());
+    vel1 *= fast_sigmoid( 100*(diff1.x()*c1 + diff1.y()*s1) );
+    vel2 *= fast_sigmoid( 100*(diff2.x()*c2 + diff2.y()*s2) );
+
     const double acc_lin  = (vel2 - vel1)*2 / ( dt1->dt() + dt2->dt() );
-   
+
 
     _error[0] = penaltyBoundToInterval(acc_lin,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     const double omega1 = angle_diff1 / dt1->dt();
     const double omega2 = angle_diff2 / dt2->dt();
     const double acc_rot  = (omega2 - omega1)*2 / ( dt1->dt() + dt2->dt() );
-      
+
     _error[1] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
+
+    // Objective functions for minimizing the overall acceleration
+    _error[2] = cfg_->powerAcceleration(std::abs(acc_lin));
+    _error[3] = cfg_->powerAcceleration(std::abs(acc_rot));
 
     TEB_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAcceleration::computeError() translational: _error[0]=%f\n",_error[0]);
     TEB_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAcceleration::computeError() rotational: _error[1]=%f\n",_error[1]);
+    TEB_ASSERT_MSG(std::isfinite(_error[2]), "EdgeAcceleration::computeError() translation: _error[2]=%f\n",_error[2]);
+    TEB_ASSERT_MSG(std::isfinite(_error[3]), "EdgeAcceleration::computeError() translation: _error[3]=%f\n",_error[3]);
   }
 
 
@@ -170,7 +182,7 @@ public:
     Eigen::Vector2d deltaS2 = conf3->estimate() - conf2->estimate();
     double dist1 = deltaS1.norm();
     double dist2 = deltaS2.norm();
-    
+
     double sum_time = deltaT1->estimate() + deltaT2->estimate();
     double sum_time_inv = 1 / sum_time;
     double dt1_inv = 1/deltaT1->estimate();
@@ -187,10 +199,10 @@ public:
     double omegadot = (omega2 - omega1) * aux0;
     double aux3 = -acc/2;
     double aux4 = -omegadot/2;
-    
+
     double dev_border_acc = penaltyBoundToIntervalDerivative(acc, tebConfig.robot_acceleration_max_trans,optimizationConfig.optimization_boundaries_epsilon,optimizationConfig.optimization_boundaries_scale,optimizationConfig.optimization_boundaries_order);
     double dev_border_omegadot = penaltyBoundToIntervalDerivative(omegadot, tebConfig.robot_acceleration_max_rot,optimizationConfig.optimization_boundaries_epsilon,optimizationConfig.optimization_boundaries_scale,optimizationConfig.optimization_boundaries_order);
-    
+
     _jacobianOplus[0].resize(2,2); // conf1
     _jacobianOplus[1].resize(2,2); // conf2
     _jacobianOplus[2].resize(2,2); // conf3
@@ -199,10 +211,10 @@ public:
     _jacobianOplus[5].resize(2,1); // angle1
     _jacobianOplus[6].resize(2,1); // angle2
     _jacobianOplus[7].resize(2,1); // angle3
-    
+
     if (aux1==0) aux1=1e-20;
     if (aux2==0) aux2=1e-20;
-  
+
     if (dev_border_acc!=0)
     {
       // TODO: double aux = aux0 * dev_border_acc;
@@ -212,7 +224,7 @@ public:
       _jacobianOplus[1](0,0) = -aux0 * ( deltaS1[0] / aux1 + deltaS2[0] / aux2 ) * dev_border_acc; // acc x2
       _jacobianOplus[1](0,1) = -aux0 * ( deltaS1[1] / aux1 + deltaS2[1] / aux2 ) * dev_border_acc; // acc y2
       _jacobianOplus[2](0,0) = aux0 * deltaS2[0] / aux2 * dev_border_acc; // acc x3
-      _jacobianOplus[2](0,1) = aux0 * deltaS2[1] / aux2 * dev_border_acc; // acc y3	
+      _jacobianOplus[2](0,1) = aux0 * deltaS2[1] / aux2 * dev_border_acc; // acc y3
       _jacobianOplus[2](0,0) = 0;
       _jacobianOplus[2](0,1) = 0;
       _jacobianOplus[3](0,0) = aux0 * (aux3 + vel1 * dt1_inv) * dev_border_acc; // acc deltaT1
@@ -221,15 +233,15 @@ public:
     else
     {
       _jacobianOplus[0](0,0) = 0; // acc x1
-      _jacobianOplus[0](0,1) = 0; // acc y1	
+      _jacobianOplus[0](0,1) = 0; // acc y1
       _jacobianOplus[1](0,0) = 0; // acc x2
       _jacobianOplus[1](0,1) = 0; // acc y2
       _jacobianOplus[2](0,0) = 0; // acc x3
-      _jacobianOplus[2](0,1) = 0; // acc y3	
+      _jacobianOplus[2](0,1) = 0; // acc y3
       _jacobianOplus[3](0,0) = 0; // acc deltaT1
       _jacobianOplus[4](0,0) = 0; // acc deltaT2
     }
-    
+
     if (dev_border_omegadot!=0)
     {
       _jacobianOplus[3](1,0) = aux0 * ( aux4 + omega1 * dt1_inv ) * dev_border_omegadot; // omegadot deltaT1
@@ -244,7 +256,7 @@ public:
       _jacobianOplus[4](1,0) = 0; // omegadot deltaT2
       _jacobianOplus[5](1,0) = 0; // omegadot angle1
       _jacobianOplus[6](1,0) = 0; // omegadot angle2
-      _jacobianOplus[7](1,0) = 0; // omegadot angle3			
+      _jacobianOplus[7](1,0) = 0; // omegadot angle3
     }
 
     _jacobianOplus[0](1,0) = 0; // omegadot x1
@@ -260,13 +272,13 @@ public:
 #endif
 #endif
 
-      
-public: 
+
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-   
+
 };
-    
-    
+
+
 /**
  * @class EdgeAccelerationStart
  * @brief Edge defining the cost function for limiting the translational and rotational acceleration at the beginning of the trajectory.
@@ -285,24 +297,24 @@ public:
  * @see EdgeAccelerationGoal
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationGoal() for defining boundary values at the end of the trajectory!
- */      
-class EdgeAccelerationStart : public BaseTebMultiEdge<2, const geometry_msgs::msg::Twist*>
+ */
+class EdgeAccelerationStart : public BaseTebMultiEdge<4, const geometry_msgs::msg::Twist*>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */	  
+   */
   EdgeAccelerationStart()
   {
     _measurement = NULL;
     this->resize(3);
   }
-  
-  
+
+
   /**
    * @brief Actual cost function
-   */   
+   */
   void computeError()
   {
     TEB_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setStartVelocity() on EdgeAccelerationStart()");
@@ -316,52 +328,60 @@ public:
     const double angle_diff = g2o::normalize_theta(pose2->theta() - pose1->theta());
     if (cfg_->trajectory.exact_arc_length && angle_diff != 0)
     {
-        const double radius =  dist/(2*sin(angle_diff/2));
-        dist = fabs( angle_diff * radius ); // actual arg length!
+      double sin = std::sin(angle_diff / 2);
+      const double radius =  dist / (2*sin);
+      dist = fabs( angle_diff * radius ); // actual arg length!
     }
-    
+
     const double vel1 = _measurement->linear.x;
     double vel2 = dist / dt->dt();
 
     // consider directions
-    //vel2 *= g2o::sign(diff[0]*cos(pose1->theta()) + diff[1]*sin(pose1->theta())); 
-    vel2 *= fast_sigmoid( 100*(diff.x()*cos(pose1->theta()) + diff.y()*sin(pose1->theta())) ); 
-    
+    double sin = std::sin(pose1->theta());
+    double cos = std::cos(pose1->theta());
+    vel2 *= fast_sigmoid( 100*(diff.x()*cos + diff.y()*sin) );
+
     const double acc_lin  = (vel2 - vel1) / dt->dt();
-    
+
     _error[0] = penaltyBoundToInterval(acc_lin,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     const double omega1 = _measurement->angular.z;
     const double omega2 = angle_diff / dt->dt();
     const double acc_rot  = (omega2 - omega1) / dt->dt();
-      
+
     _error[1] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
 
-    TEB_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAccelerationStart::computeError() translational: _error[0]=%f\n",_error[0]);
-    TEB_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAccelerationStart::computeError() rotational: _error[1]=%f\n",_error[1]);
+    // Objective functions for minimizing the overall acceleration
+    _error[2] = cfg_->powerAcceleration(std::abs(acc_lin));
+    _error[3] = cfg_->powerAcceleration(std::abs(acc_rot));
+
+    TEB_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAcceleration::computeError() translational: _error[0]=%f\n",_error[0]);
+    TEB_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAcceleration::computeError() rotational: _error[1]=%f\n",_error[1]);
+    TEB_ASSERT_MSG(std::isfinite(_error[2]), "EdgeAcceleration::computeError() translation: _error[2]=%f\n",_error[2]);
+    TEB_ASSERT_MSG(std::isfinite(_error[3]), "EdgeAcceleration::computeError() translation: _error[3]=%f\n",_error[3]);
   }
-  
+
   /**
    * @brief Set the initial velocity that is taken into account for calculating the acceleration
    * @param vel_start twist message containing the translational and rotational velocity
-   */    
+   */
   void setInitialVelocity(const geometry_msgs::msg::Twist& vel_start)
   {
     _measurement = &vel_start;
   }
-  
-public:       
+
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-};    
-    
-    
-    
+};
+
+
+
 
 /**
  * @class EdgeAccelerationGoal
  * @brief Edge defining the cost function for limiting the translational and rotational acceleration at the end of the trajectory.
- * 
+ *
  * The edge depends on three vertices \f$ \mathbf{s}_i, \mathbf{s}_{ip1}, \Delta T_i \f$, an initial velocity defined by setGoalVelocity()
  * and minimizes: \n
  * \f$ \min \textrm{penaltyInterval}( [a, omegadot ]^T ) \cdot weight \f$. \n
@@ -376,24 +396,24 @@ public:
  * @see EdgeAccelerationStart
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationStart() for defining boundary (initial) values at the end of the trajectory
- */  
-class EdgeAccelerationGoal : public BaseTebMultiEdge<2, const geometry_msgs::msg::Twist*>
+ */
+class EdgeAccelerationGoal : public BaseTebMultiEdge<4, const geometry_msgs::msg::Twist*>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */  
+   */
   EdgeAccelerationGoal()
   {
     _measurement = NULL;
     this->resize(3);
   }
-  
+
 
   /**
    * @brief Actual cost function
-   */ 
+   */
   void computeError()
   {
     TEB_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setGoalVelocity() on EdgeAccelerationGoal()");
@@ -403,87 +423,95 @@ public:
 
     // VELOCITY & ACCELERATION
 
-    const Eigen::Vector2d diff = pose_goal->position() - pose_pre_goal->position();  
+    const Eigen::Vector2d diff = pose_goal->position() - pose_pre_goal->position();
     double dist = diff.norm();
     const double angle_diff = g2o::normalize_theta(pose_goal->theta() - pose_pre_goal->theta());
     if (cfg_->trajectory.exact_arc_length  && angle_diff != 0)
     {
-        double radius =  dist/(2*sin(angle_diff/2));
-        dist = fabs( angle_diff * radius ); // actual arg length!
+      double sin = std::sin(angle_diff / 2);
+      double radius =  dist / (2*sin);
+      dist = fabs( angle_diff * radius ); // actual arg length!
     }
-    
+
     double vel1 = dist / dt->dt();
     const double vel2 = _measurement->linear.x;
-    
+
     // consider directions
-    //vel1 *= g2o::sign(diff[0]*cos(pose_pre_goal->theta()) + diff[1]*sin(pose_pre_goal->theta())); 
-    vel1 *= fast_sigmoid( 100*(diff.x()*cos(pose_pre_goal->theta()) + diff.y()*sin(pose_pre_goal->theta())) ); 
-    
+    double sin = std::sin(pose_pre_goal->theta());
+    double cos = std::cos(pose_pre_goal->theta());
+    vel1 *= fast_sigmoid( 100*(diff.x()*cos + diff.y()*sin) );
+
     const double acc_lin  = (vel2 - vel1) / dt->dt();
 
     _error[0] = penaltyBoundToInterval(acc_lin,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     const double omega1 = angle_diff / dt->dt();
     const double omega2 = _measurement->angular.z;
     const double acc_rot  = (omega2 - omega1) / dt->dt();
-      
+
     _error[1] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
 
-    TEB_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAccelerationGoal::computeError() translational: _error[0]=%f\n",_error[0]);
-    TEB_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAccelerationGoal::computeError() rotational: _error[1]=%f\n",_error[1]);
+    // Objective functions
+    _error[2] = cfg_->powerAcceleration(std::abs(acc_lin));
+    _error[3] = cfg_->powerAcceleration(std::abs(acc_rot));
+
+    TEB_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAcceleration::computeError() translational: _error[0]=%f\n",_error[0]);
+    TEB_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAcceleration::computeError() rotational: _error[1]=%f\n",_error[1]);
+    TEB_ASSERT_MSG(std::isfinite(_error[2]), "EdgeAcceleration::computeError() translation: _error[2]=%f\n",_error[2]);
+    TEB_ASSERT_MSG(std::isfinite(_error[3]), "EdgeAcceleration::computeError() translation: _error[3]=%f\n",_error[3]);
   }
-    
+
   /**
    * @brief Set the goal / final velocity that is taken into account for calculating the acceleration
    * @param vel_goal twist message containing the translational and rotational velocity
-   */    
+   */
   void setGoalVelocity(const geometry_msgs::msg::Twist& vel_goal)
   {
     _measurement = &vel_goal;
   }
-  
-public: 
+
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-}; 
-    
+};
+
 
 
 
 /**
  * @class EdgeAccelerationHolonomic
  * @brief Edge defining the cost function for limiting the translational and rotational acceleration.
- * 
+ *
  * The edge depends on five vertices \f$ \mathbf{s}_i, \mathbf{s}_{ip1}, \mathbf{s}_{ip2}, \Delta T_i, \Delta T_{ip1} \f$ and minimizes:
  * \f$ \min \textrm{penaltyInterval}( [ax, ay, omegadot } ]^T ) \cdot weight \f$. \n
  * \e ax is calculated using the difference quotient (twice) and the x position parts of all three poses \n
  * \e ay is calculated using the difference quotient (twice) and the y position parts of all three poses \n
- * \e omegadot is calculated using the difference quotient of the yaw angles followed by a normalization to [-pi, pi]. \n 
+ * \e omegadot is calculated using the difference quotient of the yaw angles followed by a normalization to [-pi, pi]. \n
  * \e weight can be set using setInformation() \n
  * \e penaltyInterval denotes the penalty function, see penaltyBoundToInterval() \n
- * The dimension of the error / cost vector is 3: the first component represents the translational acceleration (x-dir), 
+ * The dimension of the error / cost vector is 3: the first component represents the translational acceleration (x-dir),
  * the second one the strafing acceleration and the third one the rotational acceleration.
  * @see TebOptimalPlanner::AddEdgesAcceleration
  * @see EdgeAccelerationHolonomicStart
  * @see EdgeAccelerationHolonomicGoal
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationHolonomicStart() and EdgeAccelerationHolonomicGoal() for defining boundary values!
- */    
+ */
 class EdgeAccelerationHolonomic : public BaseTebMultiEdge<3, double>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */    
+   */
   EdgeAccelerationHolonomic()
   {
     this->resize(5);
   }
-    
+
   /**
    * @brief Actual cost function
-   */   
+   */
   void computeError()
   {
     TEB_ASSERT_MSG(cfg_, "You must call setTebConfig on EdgeAcceleration()");
@@ -496,48 +524,48 @@ public:
     // VELOCITY & ACCELERATION
     Eigen::Vector2d diff1 = pose2->position() - pose1->position();
     Eigen::Vector2d diff2 = pose3->position() - pose2->position();
-    
+
+    double sin_theta1 = std::sin(pose1->theta());
+    double sin_theta2 = std::sin(pose2->theta());
     double cos_theta1 = std::cos(pose1->theta());
-    double sin_theta1 = std::sin(pose1->theta()); 
     double cos_theta2 = std::cos(pose2->theta());
-    double sin_theta2 = std::sin(pose2->theta()); 
-    
+
     // transform pose2 into robot frame pose1 (inverse 2d rotation matrix)
     double p1_dx =  cos_theta1*diff1.x() + sin_theta1*diff1.y();
     double p1_dy = -sin_theta1*diff1.x() + cos_theta1*diff1.y();
     // transform pose3 into robot frame pose2 (inverse 2d rotation matrix)
     double p2_dx =  cos_theta2*diff2.x() + sin_theta2*diff2.y();
     double p2_dy = -sin_theta2*diff2.x() + cos_theta2*diff2.y();
-    
+
     double vel1_x = p1_dx / dt1->dt();
     double vel1_y = p1_dy / dt1->dt();
     double vel2_x = p2_dx / dt2->dt();
     double vel2_y = p2_dy / dt2->dt();
-    
+
     double dt12 = dt1->dt() + dt2->dt();
-    
+
     double acc_x  = (vel2_x - vel1_x)*2 / dt12;
     double acc_y  = (vel2_y - vel1_y)*2 / dt12;
-   
+
     _error[0] = penaltyBoundToInterval(acc_x,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundToInterval(acc_y,cfg_->robot.acc_lim_y,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     double omega1 = g2o::normalize_theta(pose2->theta() - pose1->theta()) / dt1->dt();
     double omega2 = g2o::normalize_theta(pose3->theta() - pose2->theta()) / dt2->dt();
     double acc_rot  = (omega2 - omega1)*2 / dt12;
-      
+
     _error[2] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
 
-    
+
     TEB_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAcceleration::computeError() translational: _error[0]=%f\n",_error[0]);
     TEB_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAcceleration::computeError() strafing: _error[1]=%f\n",_error[1]);
     TEB_ASSERT_MSG(std::isfinite(_error[2]), "EdgeAcceleration::computeError() rotational: _error[2]=%f\n",_error[2]);
   }
 
-public: 
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-   
+
 };
 
 
@@ -560,23 +588,23 @@ public:
  * @see EdgeAccelerationHolonomicGoal
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationHolonomicGoal() for defining boundary values at the end of the trajectory!
- */      
+ */
 class EdgeAccelerationHolonomicStart : public BaseTebMultiEdge<3, const geometry_msgs::msg::Twist*>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */   
+   */
   EdgeAccelerationHolonomicStart()
   {
     this->resize(3);
     _measurement = NULL;
   }
-    
+
   /**
    * @brief Actual cost function
-   */   
+   */
   void computeError()
   {
     TEB_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setStartVelocity() on EdgeAccelerationStart()");
@@ -586,14 +614,14 @@ public:
 
     // VELOCITY & ACCELERATION
     Eigen::Vector2d diff = pose2->position() - pose1->position();
-            
+
+    double sin_theta1 = std::sin(pose1->theta());
     double cos_theta1 = std::cos(pose1->theta());
-    double sin_theta1 = std::sin(pose1->theta()); 
-    
+
     // transform pose2 into robot frame pose1 (inverse 2d rotation matrix)
     double p1_dx =  cos_theta1*diff.x() + sin_theta1*diff.y();
     double p1_dy = -sin_theta1*diff.x() + cos_theta1*diff.y();
-    
+
     double vel1_x = _measurement->linear.x;
     double vel1_y = _measurement->linear.y;
     double vel2_x = p1_dx / dt->dt();
@@ -601,41 +629,41 @@ public:
 
     double acc_lin_x  = (vel2_x - vel1_x) / dt->dt();
     double acc_lin_y  = (vel2_y - vel1_y) / dt->dt();
-    
+
     _error[0] = penaltyBoundToInterval(acc_lin_x,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundToInterval(acc_lin_y,cfg_->robot.acc_lim_y,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     double omega1 = _measurement->angular.z;
     double omega2 = g2o::normalize_theta(pose2->theta() - pose1->theta()) / dt->dt();
     double acc_rot  = (omega2 - omega1) / dt->dt();
-      
+
     _error[2] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
 
     TEB_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAccelerationStart::computeError() translational: _error[0]=%f\n",_error[0]);
     TEB_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAccelerationStart::computeError() strafing: _error[1]=%f\n",_error[1]);
     TEB_ASSERT_MSG(std::isfinite(_error[2]), "EdgeAccelerationStart::computeError() rotational: _error[2]=%f\n",_error[2]);
   }
-  
+
   /**
    * @brief Set the initial velocity that is taken into account for calculating the acceleration
    * @param vel_start twist message containing the translational and rotational velocity
-   */    
+   */
   void setInitialVelocity(const geometry_msgs::msg::Twist& vel_start)
   {
     _measurement = &vel_start;
   }
-        
-public:       
+
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-};    
-    
-       
+};
+
+
 
 /**
  * @class EdgeAccelerationHolonomicGoal
  * @brief Edge defining the cost function for limiting the translational and rotational acceleration at the end of the trajectory.
- * 
+ *
  * The edge depends on three vertices \f$ \mathbf{s}_i, \mathbf{s}_{ip1}, \Delta T_i \f$, an initial velocity defined by setGoalVelocity()
  * and minimizes: \n
  * \f$ \min \textrm{penaltyInterval}( [ax, ay, omegadot ]^T ) \cdot weight \f$. \n
@@ -651,23 +679,23 @@ public:
  * @see EdgeAccelerationHolonomicStart
  * @remarks Do not forget to call setTebConfig()
  * @remarks Refer to EdgeAccelerationHolonomicStart() for defining boundary (initial) values at the end of the trajectory
- */  
+ */
 class EdgeAccelerationHolonomicGoal : public BaseTebMultiEdge<3, const geometry_msgs::msg::Twist*>
 {
 public:
 
   /**
    * @brief Construct edge.
-   */  
+   */
   EdgeAccelerationHolonomicGoal()
   {
     _measurement = NULL;
     this->resize(3);
   }
-  
+
   /**
    * @brief Actual cost function
-   */ 
+   */
   void computeError()
   {
     TEB_ASSERT_MSG(cfg_ && _measurement, "You must call setTebConfig() and setGoalVelocity() on EdgeAccelerationGoal()");
@@ -677,53 +705,53 @@ public:
 
     // VELOCITY & ACCELERATION
 
-    Eigen::Vector2d diff = pose_goal->position() - pose_pre_goal->position();    
-    
+    Eigen::Vector2d diff = pose_goal->position() - pose_pre_goal->position();
+
+    double sin_theta1 = std::sin(pose_pre_goal->theta());
     double cos_theta1 = std::cos(pose_pre_goal->theta());
-    double sin_theta1 = std::sin(pose_pre_goal->theta()); 
-    
+
     // transform pose2 into robot frame pose1 (inverse 2d rotation matrix)
     double p1_dx =  cos_theta1*diff.x() + sin_theta1*diff.y();
     double p1_dy = -sin_theta1*diff.x() + cos_theta1*diff.y();
-   
+
     double vel1_x = p1_dx / dt->dt();
     double vel1_y = p1_dy / dt->dt();
     double vel2_x = _measurement->linear.x;
     double vel2_y = _measurement->linear.y;
-    
+
     double acc_lin_x  = (vel2_x - vel1_x) / dt->dt();
     double acc_lin_y  = (vel2_y - vel1_y) / dt->dt();
 
     _error[0] = penaltyBoundToInterval(acc_lin_x,cfg_->robot.acc_lim_x,cfg_->optim.penalty_epsilon);
     _error[1] = penaltyBoundToInterval(acc_lin_y,cfg_->robot.acc_lim_y,cfg_->optim.penalty_epsilon);
-    
+
     // ANGULAR ACCELERATION
     double omega1 = g2o::normalize_theta(pose_goal->theta() - pose_pre_goal->theta()) / dt->dt();
     double omega2 = _measurement->angular.z;
     double acc_rot  = (omega2 - omega1) / dt->dt();
-      
+
     _error[2] = penaltyBoundToInterval(acc_rot,cfg_->robot.acc_lim_theta,cfg_->optim.penalty_epsilon);
 
     TEB_ASSERT_MSG(std::isfinite(_error[0]), "EdgeAccelerationGoal::computeError() translational: _error[0]=%f\n",_error[0]);
     TEB_ASSERT_MSG(std::isfinite(_error[1]), "EdgeAccelerationGoal::computeError() strafing: _error[1]=%f\n",_error[1]);
     TEB_ASSERT_MSG(std::isfinite(_error[2]), "EdgeAccelerationGoal::computeError() rotational: _error[2]=%f\n",_error[2]);
   }
-  
-  
+
+
   /**
    * @brief Set the goal / final velocity that is taken into account for calculating the acceleration
    * @param vel_goal twist message containing the translational and rotational velocity
-   */    
+   */
   void setGoalVelocity(const geometry_msgs::msg::Twist& vel_goal)
   {
     _measurement = &vel_goal;
   }
-  
 
-public: 
+
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-}; 
-    
+};
+
 
 
 

--- a/teb_local_planner/src/optimal_planner.cpp
+++ b/teb_local_planner/src/optimal_planner.cpp
@@ -796,10 +796,12 @@ void TebOptimalPlanner::AddEdgesAcceleration()
     
   if (cfg_->robot.max_vel_y == 0 || cfg_->robot.acc_lim_y == 0) // non-holonomic robot
   {
-    Eigen::Matrix<double,2,2> information;
+    Eigen::Matrix<double,4,4> information;
     information.fill(0);
     information(0,0) = cfg_->optim.weight_acc_lim_x;
     information(1,1) = cfg_->optim.weight_acc_lim_theta;
+    information(2,2) = cfg_->optim.weight_minimize_acc_x;
+    information(3,3) = cfg_->optim.weight_minimize_acc_theta;
     
     // check if an initial velocity should be taken into accound
     if (vel_start_.first)

--- a/teb_local_planner/src/teb_config.cpp
+++ b/teb_local_planner/src/teb_config.cpp
@@ -115,6 +115,8 @@ void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, 
   declare_parameter_if_not_declared(nh, name + "." + "weight_acc_lim_x", rclcpp::ParameterValue(optim.weight_acc_lim_x));
   declare_parameter_if_not_declared(nh, name + "." + "weight_acc_lim_y", rclcpp::ParameterValue(optim.weight_acc_lim_y));
   declare_parameter_if_not_declared(nh, name + "." + "weight_acc_lim_theta", rclcpp::ParameterValue(optim.weight_acc_lim_theta));
+  declare_parameter_if_not_declared(nh, name + "." + "weight_minimize_acc_x", rclcpp::ParameterValue(optim.weight_minimize_acc_x));
+  declare_parameter_if_not_declared(nh, name + "." + "weight_minimize_acc_theta", rclcpp::ParameterValue(optim.weight_minimize_acc_theta));
   declare_parameter_if_not_declared(nh, name + "." + "weight_kinematics_nh", rclcpp::ParameterValue(optim.weight_kinematics_nh));
   declare_parameter_if_not_declared(nh, name + "." + "weight_kinematics_forward_drive", rclcpp::ParameterValue(optim.weight_kinematics_forward_drive));
   declare_parameter_if_not_declared(nh, name + "." + "weight_kinematics_turning_radius", rclcpp::ParameterValue(optim.weight_kinematics_turning_radius));
@@ -128,6 +130,7 @@ void TebConfig::declareParameters(const nav2_util::LifecycleNode::SharedPtr nh, 
   declare_parameter_if_not_declared(nh, name + "." + "weight_prefer_rotdir", rclcpp::ParameterValue(optim.weight_prefer_rotdir));
   declare_parameter_if_not_declared(nh, name + "." + "weight_adapt_factor", rclcpp::ParameterValue(optim.weight_adapt_factor));
   declare_parameter_if_not_declared(nh, name + "." + "obstacle_cost_exponent", rclcpp::ParameterValue(optim.obstacle_cost_exponent));
+  declare_parameter_if_not_declared(nh, name + "." + "minimize_acc_exponent", rclcpp::ParameterValue(optim.minimize_acc_exponent));
   declare_parameter_if_not_declared(nh, name + "." + "weight_velocity_obstacle_ratio", rclcpp::ParameterValue(optim.weight_velocity_obstacle_ratio));
 
   // Homotopy Class Planner
@@ -240,6 +243,8 @@ void TebConfig::loadRosParamFromNodeHandle(const nav2_util::LifecycleNode::Share
   nh->get_parameter_or(name + "." + "weight_acc_lim_x", optim.weight_acc_lim_x, optim.weight_acc_lim_x);
   nh->get_parameter_or(name + "." + "weight_acc_lim_y", optim.weight_acc_lim_y, optim.weight_acc_lim_y);
   nh->get_parameter_or(name + "." + "weight_acc_lim_theta", optim.weight_acc_lim_theta, optim.weight_acc_lim_theta);
+  nh->get_parameter_or(name + "." + "weight_minimize_acc_x", optim.weight_minimize_acc_x, optim.weight_minimize_acc_x);
+  nh->get_parameter_or(name + "." + "weight_minimize_acc_theta", optim.weight_minimize_acc_theta, optim.weight_minimize_acc_theta);
   nh->get_parameter_or(name + "." + "weight_kinematics_nh", optim.weight_kinematics_nh, optim.weight_kinematics_nh);
   nh->get_parameter_or(name + "." + "weight_kinematics_forward_drive", optim.weight_kinematics_forward_drive, optim.weight_kinematics_forward_drive);
   nh->get_parameter_or(name + "." + "weight_kinematics_turning_radius", optim.weight_kinematics_turning_radius, optim.weight_kinematics_turning_radius);
@@ -253,6 +258,7 @@ void TebConfig::loadRosParamFromNodeHandle(const nav2_util::LifecycleNode::Share
   nh->get_parameter_or(name + "." + "weight_prefer_rotdir", optim.weight_prefer_rotdir, optim.weight_prefer_rotdir);
   nh->get_parameter_or(name + "." + "weight_adapt_factor", optim.weight_adapt_factor, optim.weight_adapt_factor);
   nh->get_parameter_or(name + "." + "obstacle_cost_exponent", optim.obstacle_cost_exponent, optim.obstacle_cost_exponent);
+  nh->get_parameter_or(name + "." + "minimize_acc_exponent", optim.minimize_acc_exponent, optim.minimize_acc_exponent);
   nh->get_parameter_or(name + "." + "weight_velocity_obstacle_ratio", optim.weight_velocity_obstacle_ratio, optim.weight_velocity_obstacle_ratio);
   
   // Homotopy Class Planner
@@ -390,6 +396,10 @@ void TebConfig::on_parameter_event_callback(
         optim.weight_acc_lim_y = value.double_value;
       } else if (name == node_name + ".weight_acc_lim_theta") {
         optim.weight_acc_lim_theta = value.double_value;
+      } else if (name == node_name + ".weight_minimize_acc_x") {
+        optim.weight_minimize_acc_x = value.double_value;
+      } else if (name == node_name + ".weight_minimize_acc_theta") {
+        optim.weight_minimize_acc_theta = value.double_value;
       } else if (name == node_name + ".weight_kinematics_nh") {
         optim.weight_kinematics_nh = value.double_value;
       } else if (name == node_name + ".weight_kinematics_forward_drive") {
@@ -416,7 +426,10 @@ void TebConfig::on_parameter_event_callback(
         optim.weight_adapt_factor = value.double_value;
       } else if (name == node_name + ".obstacle_cost_exponent") {
         optim.obstacle_cost_exponent = value.double_value;
+      } else if (name == node_name + ".minimize_acc_exponent") {
+        optim.minimize_acc_exponent = value.integer_value;
       }
+
       // Homotopy Class Planner
       else if (name == node_name + ".selection_cost_hysteresis") {
         hcp.selection_cost_hysteresis = value.double_value;


### PR DESCRIPTION
### Why
For some robots (like ours) it is desirable to (1) minimize the acceleration and (2) set a maximum threshold for it.

### What
Added an additional objective function to minimize the acceleration for non-holonomic vehicles.

### How

1. Modified the `g2o` type for `EdgeAcceleration` and `EdgeAccelerationStart`
2. Added the necessary weights to configure the objective function.
3. Set the default weight to zero to keep the nominal behavior of the planner.

### Warning
I did not modify the analytical Jacobian calculation.