### PR TITLE
[bugfix] locate g2o correctly according to the install structure

### DIFF
--- a/teb_local_planner/cmake_modules/FindG2O.cmake
+++ b/teb_local_planner/cmake_modules/FindG2O.cmake
@@ -18,9 +18,16 @@ IF(UNIX)
 
   MESSAGE(STATUS "Searching for g2o ...")
   FIND_PATH(G2O_INCLUDE_DIR
-    NAMES core math_groups types
+    NAMES core types
     PATHS /usr/local /usr
-    PATH_SUFFIXES include/g2o include)
+    PATH_SUFFIXES include)
+
+  IF (NOT G2O_INCLUDE_DIR)
+    FIND_PATH(G2O_INCLUDE_DIR
+      NAMES g2o/core g2o/types
+      PATHS /usr/local /usr
+      PATH_SUFFIXES include)
+  ENDIF (NOT G2O_INCLUDE_DIR)
 
   IF (G2O_INCLUDE_DIR)
     MESSAGE(STATUS "Found g2o headers in: ${G2O_INCLUDE_DIR}")


### PR DESCRIPTION
### Why
Could not compile `teb_local_planner` when `g2o` was compiled from source

### What
Fix the rule to find `g2o`.

### How
I added simple CMake instructions to the `FindG2O.cmake` file to account for the way that `colcon` organizes the install directory.

### Disclaimer
Proper use of CMake would delegate the responsibility of providing a proper `FindG2O.cmake` to the `g2o` library during its installation process. However, to avoid changing to much the CMakeLists structure of both TEB and G2O I chose to modify the "frowned upon" custom `FindG2O.cmake` present in the `teb_local_planner` package.