### PR TITLE
Fix unit tests ros2

### DIFF
--- a/teb_local_planner/CMakeLists.txt
+++ b/teb_local_planner/CMakeLists.txt
@@ -151,12 +151,18 @@ pluginlib_export_plugin_description_file(nav2_core teb_local_planner_plugin.xml)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
-  #ament_add_gtest(homotopy_class_planner_test
-  #    test/homotopy_class_planner_test.cpp
-  #)
-  #target_link_libraries(homotopy_class_planner_test
-  #    teb_local_planner
-  #)
+  ament_add_gtest(homotopy_class_planner_test
+     test/homotopy_class_planner_test.cpp
+  )
+  target_link_libraries(homotopy_class_planner_test
+     teb_local_planner
+  )
+  ament_add_gtest(teb_basics_test
+     test/teb_basics.cpp
+  )
+  target_link_libraries(teb_basics_test
+     teb_local_planner
+  )
 endif()
 
 ament_package()

--- a/teb_local_planner/include/teb_local_planner/teb_config.h
+++ b/teb_local_planner/include/teb_local_planner/teb_config.h
@@ -341,6 +341,7 @@ public:
 
     optim.weight_adapt_factor = 2.0;
     optim.obstacle_cost_exponent = 1.0;
+    optim.minimize_acc_exponent = 1.0;
 
     // Homotopy Class Planner
 

--- a/teb_local_planner/test/homotopy_class_planner_test.cpp
+++ b/teb_local_planner/test/homotopy_class_planner_test.cpp
@@ -1,11 +1,12 @@
 #include "teb_local_planner/homotopy_class_planner.h"
 #include <rclcpp/rclcpp.hpp>
 
+#include <thread>
 #include <gtest/gtest.h>
 
 class HomotopyClassPlannerTest : public teb_local_planner::HomotopyClassPlanner {
     public:
-    void SetUp(rclcpp::Node::SharedPtr node) {
+    void SetUp(rclcpp_lifecycle::LifecycleNode::SharedPtr node) {
         teb_local_planner::RobotFootprintModelPtr robot_model;
         teb_local_planner::TebVisualizationPtr visualization;
         teb_local_planner::HomotopyClassPlannerPtr homotopy_class_planner;
@@ -13,7 +14,7 @@ class HomotopyClassPlannerTest : public teb_local_planner::HomotopyClassPlanner 
         robot_model.reset(new teb_local_planner::CircularRobotFootprint(0.25));
         
         obstacles.push_back(
-            teb_local_planner::ObstaclePtr(new teb_local_planner::PointObstacle(2, 2))
+            teb_local_planner::ObstaclePtr(new teb_local_planner::PointObstacle(1, 2))
         );
 
         obstacles.push_back(
@@ -28,6 +29,9 @@ class HomotopyClassPlannerTest : public teb_local_planner::HomotopyClassPlanner 
             new teb_local_planner::TebVisualization(node, cfg)
         );
 
+        visualization->on_configure();
+        visualization->on_activate();
+
         cfg.hcp.visualize_hc_graph = true;
 
         initialize(node, cfg, &obstacles, robot_model, visualization);
@@ -36,14 +40,43 @@ class HomotopyClassPlannerTest : public teb_local_planner::HomotopyClassPlanner 
     teb_local_planner::TebConfig cfg;
 };
 
+class VisualizationSubscriber : public rclcpp::Node {
+    public:
+    VisualizationSubscriber() : rclcpp::Node("visualization_subscriber") {
+      this->create_subscription<geometry_msgs::msg::PoseArray>("teb_poses", 1, std::bind(&VisualizationSubscriber::tebPosesCallback, this, std::placeholders::_1));
+    }
+
+    geometry_msgs::msg::PoseArray teb_poses;
+    void tebPosesCallback(const geometry_msgs::msg::PoseArray::SharedPtr input_poses) {
+      if (input_poses) teb_poses = *input_poses;
+    }
+
+    private:
+    rclcpp::Subscription<geometry_msgs::msg::PoseArray>::SharedPtr teb_poses_sub_;
+};
+
+bool isPoseEqual(geometry_msgs::msg::Pose poseA, geometry_msgs::msg::Pose poseB, double xy_goal_tolerance = 0.2) {
+    double dx = abs(poseA.position.x - poseB.position.x);
+    double dy = abs(poseA.position.y - poseB.position.y);
+
+    std::cout << "Pose = [" << poseA.position.x << "," << poseA.position.y << "]" << std::endl;
+
+    if (sqrt(dx*dx+dy*dy) <= xy_goal_tolerance) return true;
+
+    return false;
+}
+
 TEST(test, test) {
     HomotopyClassPlannerTest test;
-    rclcpp::Node::SharedPtr node( new rclcpp::Node("test") );
+    rclcpp_lifecycle::LifecycleNode::SharedPtr node(new rclcpp_lifecycle::LifecycleNode("test"));
+    std::shared_ptr<VisualizationSubscriber> visualize_sub_node = std::make_shared<VisualizationSubscriber>();
     test.SetUp(node);
 
     using namespace teb_local_planner;
     PoseSE2 start(0, 0, 0);
+    PoseSE2 via(2, 2, 0);
     PoseSE2 goal(5, 5, 0);
+    
     geometry_msgs::msg::Twist twist;
     twist.linear.x = 0;
     twist.linear.y = 0;
@@ -52,25 +85,35 @@ TEST(test, test) {
     std::vector<geometry_msgs::msg::PoseStamped> initial_plan;
     
     geometry_msgs::msg::PoseStamped start_pose;
+    geometry_msgs::msg::PoseStamped via_pose;
     geometry_msgs::msg::PoseStamped goal_pose;
 
     start.toPoseMsg(start_pose.pose);
+    via.toPoseMsg(via_pose.pose);
     goal.toPoseMsg(goal_pose.pose);
     
     initial_plan.push_back(start_pose);
+    initial_plan.push_back(via_pose);
     initial_plan.push_back(goal_pose);
 
     test.plan(initial_plan, &twist, false);
     //homotopy_class_planner_->exploreEquivalenceClassesAndInitTebs(start, goal, 0.3, &twist);
     
-    rclcpp::Rate rate(10);
-    while(rclcpp::ok()) {
+    rclcpp::executors::SingleThreadedExecutor exe;
+    exe.add_node(node->get_node_base_interface());
+    exe.add_node(visualize_sub_node);
+
+    while(!isPoseEqual(visualize_sub_node->teb_poses.poses.back(), goal_pose.pose)) {
         test.visualize();
-        rclcpp::spin_some(node);
-        rate.sleep();
+        exe.spin_some();
+        rclcpp::sle
     }
 
-    ASSERT_TRUE(true);
+    bool goal_reached = isPoseEqual(visualize_sub_node->teb_poses.poses.back(), goal_pose.pose);
+    ASSERT_TRUE(goal_reached);
+
+    exe.cancel();        
+    rclcpp::shutdown();
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
```
UpdateCTestConfiguration  from :/home/ros/workspace/cmr-stack/build/teb_local_planner/CTestConfiguration.ini
Parse Config file:/home/ros/workspace/cmr-stack/build/teb_local_planner/CTestConfiguration.ini
   Site: erwin-cmr
   Build name: (empty)
 Add coverage exclude regular expressions.
SetCTestConfiguration:CMakeCommand:/opt/cmake-3.14.6-Linux-x86_64/bin/cmake
Create new tag: 20220118-1440 - Experimental
UpdateCTestConfiguration  from :/home/ros/workspace/cmr-stack/build/teb_local_planner/CTestConfiguration.ini
Parse Config file:/home/ros/workspace/cmr-stack/build/teb_local_planner/CTestConfiguration.ini
Test project /home/ros/workspace/cmr-stack/build/teb_local_planner
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: homotopy_class_planner_test

1: Test command: /usr/bin/python3.8 "-u" "/opt/ros/rolling/share/ament_cmake_test/cmake/run_test.py" "/home/ros/workspace/cmr-stack/build/teb_local_planner/test_results/teb_local_planner/homotopy_class_planner_test.gtest.xml" "--package-name" "teb_local_planner" "--output-file" "/home/ros/workspace/cmr-stack/build/teb_local_planner/ament_cmake_gtest/homotopy_class_planner_test.txt" "--command" "/home/ros/workspace/cmr-stack/build/teb_local_planner/homotopy_class_planner_test" "--gtest_output=xml:/home/ros/workspace/cmr-stack/build/teb_local_planner/test_results/teb_local_planner/homotopy_class_planner_test.gtest.xml"
1: Test timeout computed to be: 60
1: -- run_test.py: invoking following command in '/home/ros/workspace/cmr-stack/build/teb_local_planner':
1:  - /home/ros/workspace/cmr-stack/build/teb_local_planner/homotopy_class_planner_test --gtest_output=xml:/home/ros/workspace/cmr-stack/build/teb_local_planner/test_results/teb_local_planner/homotopy_class_planner_test.gtest.xml
1: [==========] Running 1 test from 1 test suite.
1: [----------] Global test environment set-up.
1: [----------] 1 test from HomotopyPlannerTest
1: [ RUN      ] HomotopyPlannerTest.goToGoal
1: [       OK ] HomotopyPlannerTest.goToGoal (231 ms)
1: [----------] 1 test from HomotopyPlannerTest (231 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 1 test from 1 test suite ran. (231 ms total)
1: [  PASSED  ] 1 test.
1: -- run_test.py: return code 0
1: -- run_test.py: inject classname prefix into gtest result file '/home/ros/workspace/cmr-stack/build/teb_local_planner/test_results/teb_local_planner/homotopy_class_planner_test.gtest.xml'
1: -- run_test.py: verify result file '/home/ros/workspace/cmr-stack/build/teb_local_planner/test_results/teb_local_planner/homotopy_class_planner_test.gtest.xml'
1/2 Test #1: homotopy_class_planner_test ......   Passed    0.38 sec
test 2
    Start 2: teb_basics_test

2: Test command: /usr/bin/python3.8 "-u" "/opt/ros/rolling/share/ament_cmake_test/cmake/run_test.py" "/home/ros/workspace/cmr-stack/build/teb_local_planner/test_results/teb_local_planner/teb_basics_test.gtest.xml" "--package-name" "teb_local_planner" "--output-file" "/home/ros/workspace/cmr-stack/build/teb_local_planner/ament_cmake_gtest/teb_basics_test.txt" "--command" "/home/ros/workspace/cmr-stack/build/teb_local_planner/teb_basics_test" "--gtest_output=xml:/home/ros/workspace/cmr-stack/build/teb_local_planner/test_results/teb_local_planner/teb_basics_test.gtest.xml"
2: Test timeout computed to be: 60
2: -- run_test.py: invoking following command in '/home/ros/workspace/cmr-stack/build/teb_local_planner':
2:  - /home/ros/workspace/cmr-stack/build/teb_local_planner/teb_basics_test --gtest_output=xml:/home/ros/workspace/cmr-stack/build/teb_local_planner/test_results/teb_local_planner/teb_basics_test.gtest.xml
2: [==========] Running 3 tests from 1 test suite.
2: [----------] Global test environment set-up.
2: [----------] 3 tests from TEBBasic
2: [ RUN      ] TEBBasic.autoResizeLargeValueAtEnd
2: [       OK ] TEBBasic.autoResizeLargeValueAtEnd (1 ms)
2: [ RUN      ] TEBBasic.autoResizeSmallValueAtEnd
2: [       OK ] TEBBasic.autoResizeSmallValueAtEnd (0 ms)
2: [ RUN      ] TEBBasic.autoResize
2: [       OK ] TEBBasic.autoResize (0 ms)
2: [----------] 3 tests from TEBBasic (1 ms total)
2: 
2: [----------] Global test environment tear-down
2: [==========] 3 tests from 1 test suite ran. (1 ms total)
2: [  PASSED  ] 3 tests.
2: -- run_test.py: return code 0
2: -- run_test.py: inject classname prefix into gtest result file '/home/ros/workspace/cmr-stack/build/teb_local_planner/test_results/teb_local_planner/teb_basics_test.gtest.xml'
2: -- run_test.py: verify result file '/home/ros/workspace/cmr-stack/build/teb_local_planner/test_results/teb_local_planner/teb_basics_test.gtest.xml'
2/2 Test #2: teb_basics_test ..................   Passed    0.11 sec

[0;32m100% tests passed[0;0m, 0 tests failed[0;0m out of 2

Label Time Summary:
gtest    =   0.49 sec*proc (2 tests)

Total Test time (real) =   0.49 sec
```